### PR TITLE
Fix RSpec one-liner example descriptions

### DIFF
--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -68,8 +68,12 @@ module OpenTelemetry
 
         def example_finished(notification)
           pop_and_finalize_span do |span|
-            result = notification.example.execution_result
+            example = notification.example
+            result = example.execution_result
 
+            # Update name and full_description for one-liner examples where description is generated after execution
+            span.name = example.description
+            span.set_attribute('rspec.example.full_description', example.full_description.to_s)
             span.set_attribute('rspec.example.result', result.status.to_s)
 
             add_exception_and_failures(span, result.exception)

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -326,6 +326,26 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
         _(subject.events[1].attributes['exception.message']).must_equal 'another-error'
       end
     end
+
+    describe 'one-liner syntax' do
+      subject do
+        run_example do
+          it { is_expected.not_to be_nil }
+        end
+      end
+
+      it 'has a name that matches the auto-generated description' do
+        _(subject.name).must_equal 'is expected not to be nil'
+      end
+
+      it 'has a full_description attribute that includes the group description' do
+        _(subject.attributes['rspec.example.full_description']).must_equal 'group one is expected not to be nil'
+      end
+
+      it 'records when the example passes' do
+        _(subject.attributes['rspec.example.result']).must_equal 'passed'
+      end
+    end
   end
 
   describe 'using a custom tracer provider' do


### PR DESCRIPTION
## Why?

Span names and full descriptions for RSpec one-liner syntax (like `it { is_expected.not_to be_nil }`) were incorrectly showing file locations instead of the matcher-generated descriptions. This made tracing output less useful for tests using the concise one-liner syntax.

## How?

RSpec generates descriptions for one-liner examples after execution, when the matcher runs. The formatter was capturing `description` and `full_description` at `example_started` time, before these values were populated. 

The fix updates both the span name and `full_description` attribute in the `example_finished` callback, after RSpec has generated the proper description from the matcher. This ensures accurate span names and descriptions for both one-liner and traditional examples.

---

**Note:** Upstream PR created at https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1712