### PR TITLE
feat: add example.id attribute to RSpec instrumentation

### DIFF
--- a/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
+++ b/instrumentation/rspec/lib/opentelemetry/instrumentation/rspec/formatter.rb
@@ -58,6 +58,7 @@ module OpenTelemetry
         def example_started(notification)
           example = notification.example
           attributes = {
+            'rspec.example.id' => example.id.to_s,
             'rspec.example.location' => example.location.to_s,
             'rspec.example.full_description' => example.full_description.to_s,
             'rspec.example.described_class' => example.metadata[:described_class].to_s

--- a/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
+++ b/instrumentation/rspec/test/opentelemetry/instrumentation/rspec/formatter_test.rb
@@ -131,6 +131,10 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
         _(subject.attributes['rspec.example.location']).must_match %r{\./test/opentelemetry/instrumentation/rspec/formatter_test.rb:\d+}
       end
 
+      it 'has an id attribute' do
+        _(subject.attributes['rspec.example.id']).must_match %r{\./test/opentelemetry/instrumentation/rspec/formatter_test.rb\[\d+:\d+\]}
+      end
+
       it 'records when the example passes' do
         _(subject.attributes['rspec.example.result']).must_equal 'passed'
       end
@@ -344,6 +348,32 @@ describe OpenTelemetry::Instrumentation::RSpec::Formatter do
 
       it 'records when the example passes' do
         _(subject.attributes['rspec.example.result']).must_equal 'passed'
+      end
+    end
+
+    describe 'dynamic examples with same location' do
+      it 'have unique example.id attributes' do
+        spans = run_rspec_with_tracing do
+          RSpec.describe('dynamic examples') do
+            [1, 2, 3].each do |num|
+              example("example #{num}") { expect(num).to be_positive }
+            end
+          end
+        end
+
+        example_spans = spans.select { |span| span.name.start_with?('example ') }
+        _(example_spans.size).must_equal 3
+
+        # All examples have the same location (same line in the loop)
+        locations = example_spans.map { |span| span.attributes['rspec.example.location'] }
+        _(locations.uniq.size).must_equal 1
+
+        # But each has a unique id
+        ids = example_spans.map { |span| span.attributes['rspec.example.id'] }
+        _(ids.uniq.size).must_equal 3
+        ids.each do |id|
+          _(id).must_match %r{\./test/opentelemetry/instrumentation/rspec/formatter_test.rb\[\d+:\d+\]}
+        end
       end
     end
   end


### PR DESCRIPTION
This PR adds RSpec's `example.id` as a span attribute to provide unique identification for each test example.

The existing `rspec.example.location` attribute cannot uniquely identify dynamically generated examples (e.g., examples created within loops or using data tables) because multiple examples share the same source file location. RSpec's `example.id` provides a stable, unique identifier across test runs even for these dynamic cases.

Example format: `./spec/foo_spec.rb[1:2:3]`

This enables better correlation and tracking of individual test executions in observability platforms.

---

Upstream PR: https://github.com/open-telemetry/opentelemetry-ruby-contrib/pull/1713